### PR TITLE
Removal of reference to platform-issues within "README.md".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [Character Identifier](https://dbaron.org/mozilla/char-identifier/) is a [Web Extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) that adds a browser context menu item for selected text that provides more information (from the [Unicode database](http://www.unicode.org/ucd/)) about the characters selected.
 
-It was previously (in this same repository) a Firefox extension using the old XUL-based Firefox extensions API.  As a Web extension, it works in both Firefox, Chrome, and Edge.
+It was previously (in this same repository) a Firefox extension using the old XUL-based Firefox extensions API. Because it is a Web extension, it works in both Firefox, Chrome, and Edge.
 
 Build it by running `make`.  The unpacked output will be in `output/`, and the packaged extension will be in `char-identifier.zip`.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 It was previously (in this same repository) a Firefox extension using the old XUL-based Firefox extensions API. Because it is a Web extension, it works in both Firefox, Chrome, and Edge.
 
-Build it by running `make`.  The unpacked output will be in `output/`, and the packaged extension will be in `char-identifier.zip`.
+Build it by running `make`. The unpacked output will be in `output/`, and the packaged extension will be in `char-identifier.zip`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [Character Identifier](https://dbaron.org/mozilla/char-identifier/) is a [Web Extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) that adds a browser context menu item for selected text that provides more information (from the [Unicode database](http://www.unicode.org/ucd/)) about the characters selected.
 
-It was previously (in this same repository) a Firefox extension using the old XUL-based Firefox extensions API.  As a Web extension, it works in both Firefox and Chrome, but crashes the entire browser reliably in Edge, perhaps due to [Issue #10831621](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10831621/).
+It was previously (in this same repository) a Firefox extension using the old XUL-based Firefox extensions API.  As a Web extension, it works in both Firefox, Chrome, and Edge.
 
 Build it by running `make`.  The unpacked output will be in `output/`, and the packaged extension will be in `char-identifier.zip`.


### PR DESCRIPTION
I believe that "https://blogs.windows.com/msedgedev/2016/04/06/edgehtml-issue-tracker/" was for EdgeHTML, rather than Microsoft's fork of Chromium, which is the new Edge.